### PR TITLE
Emon vs notes for north america

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -26,11 +26,11 @@ away from the load on the Neutral.
 
 4. Plug emonVs into mains power via a domestic wall socket
 
-6. (optionally) If you have the RaspberryPi 4 variant of the emonPi2 a hard wired Ethernet internet/LAN connection can be connected.
+5. (optionally) If you have the RaspberryPi 4 variant of the emonPi2 a hard wired Ethernet internet/LAN connection can be connected.
 
-7. Switch on mains socket. The display on the emonPi2 will show `emonPi2, starting..`. On the SD card side of the case the RaspberryPi 4 indicator LED should be visible through the black face plate.
+6. Switch on mains socket. The display on the emonPi2 will show `emonPi2, starting..`. On the SD card side of the case the RaspberryPi 4 indicator LED should be visible through the black face plate.
 
-8. Continue with step 5. emonBase Setup below.
+7. If using Ethernet, continue with [step 5. Connecting via Ethernet](#connecting-via-ethernet). If using WiFi, continue with [step 6. Connecting via WiFi](#connecting-via-wifi).
 
 ```{admonition} Instructions for safe use
 - Clip-on CT sensors are non-invasive and should not have direct contact with the AC mains. As a precaution, we recommend ensuring all cables are fully isolated prior to installing. If in doubt seek professional assistance.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,5 @@
 ---
-github_url: "https://github.com/openenergymonitor/emonpi2/blob/main/docs/emonpi2_emonbase_install.md"
+github_url: "https://github.com/openenergymonitor/emonpi2/blob/main/docs/install.md"
 ---
 
 # emonPi2 Install Guide

--- a/docs/install.md
+++ b/docs/install.md
@@ -49,13 +49,17 @@ A good place to start is to assess the location where you wish to install the em
 
 ## 1. emonVs installation
 
-There are two different ways of installing the emonVs voltage sensor:
+There are two different ways of installing the [emonVs voltage sensor](https://shop.openenergymonitor.com/power-supplies/):
 
 **Using the mains plug supplied:** If you have a convenient socket near-by this will be the easiest and quickest option.<br>
 
 **Direct installation:** The emonVs can be hardwired by a suitably competent person into a 6A or lower circuit protection device in the fuse board (consumer unit) or a 3A fused spur. The supplied emonVs mains power cable has a cross sectional area of 1.0mm<sup>2</sup>. This can provide a tidy installation if no socket is available and helps ensure higher monitoring uptime if sockets are at risk of being unplugged for use by other appliances.
 
 The emonVs unit can be wall mounted using the brackets on the enclosure.
+
+If in North America, you likely want the [3-phase version of the emonVS](https://shop.openenergymonitor.com/emonvs-3-phase-no-plug/), as this will allow you to use the split phase [firmware](firmware.md). The split phase firmware enables the most accurate power measurements.
+
+If you plan on using an [emonTx5 with your emonPi2](../emontx5/install.md), you will likely want an [emonVs RJ45 duplicator](https://shop.openenergymonitor.com/emonvs-rj45-duplicator/) to use a single emonVs with both devices.
 
 ## 2. CT sensor installation
 


### PR DESCRIPTION
This change builds on https://github.com/openenergymonitor/emonpi2/pull/5 If that PR is merged first, it will make this one easier to read.

This documentation may help other people in North America be confident they are buying the correct hardware when purchasing an energy monitoring system. It also can save them from buying two emonVs devices for their emonPi2 and emonTx5 when they could have just bought an RJ45 duplicator.

It also explains **why** they'll want a 3-phase emonVs and links to the firmware page (which I also plan on updating to reflect that there is now a split phase firmware option for North Americans).